### PR TITLE
Talkative yowon stays in context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ CHANGELOG.ignore.md
 # nix related
 .direnv
 .envrc
+**/__pycache__/

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Install globally:
 npm install -g @openai/codex
 ```
 
+For Python enthusiasts, an experimental entry point is available:
+
+```shell
+python codex-cli/bin/codex.py --help
+```
+
 Next, set your OpenAI API key as an environment variable:
 
 ```shell

--- a/codex-cli/bin/codex.py
+++ b/codex-cli/bin/codex.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Unified entry point for the Codex CLI in Python."""
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+# Determine whether the user explicitly wants the Rust CLI.
+wants_native = Path(__file__).with_name("use-native").exists() or (
+    os.getenv("CODEX_RUST") is not None
+    and os.getenv("CODEX_RUST").lower() in {"1", "true", "yes"}
+)
+
+if wants_native:
+    platform = sys.platform
+    arch = os.uname().machine
+
+    target_triple = None
+    if platform.startswith("linux"):
+        if arch == "x86_64":
+            target_triple = "x86_64-unknown-linux-musl"
+        elif arch == "aarch64":
+            target_triple = "aarch64-unknown-linux-musl"
+    elif platform == "darwin":
+        if arch == "x86_64":
+            target_triple = "x86_64-apple-darwin"
+        elif arch == "arm64":
+            target_triple = "aarch64-apple-darwin"
+
+    if not target_triple:
+        raise RuntimeError(f"Unsupported platform: {platform} ({arch})")
+
+    binary_path = Path(__file__).resolve().parent.parent / "bin" / f"codex-{target_triple}"
+    result = subprocess.run([str(binary_path), *sys.argv[1:]])
+    sys.exit(result.returncode)
+
+# Fallback: execute the original JavaScript CLI
+cli_path = Path(__file__).resolve().parent.parent / "dist" / "cli.js"
+try:
+    subprocess.run(["node", str(cli_path), *sys.argv[1:]], check=True)
+except subprocess.CalledProcessError as err:
+    print(err, file=sys.stderr)
+    sys.exit(err.returncode)

--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -25,7 +25,8 @@ Codex supports a rich set of configuration options. Note that the Rust CLI uses 
 
 Codex CLI functions as an MCP client that can connect to MCP servers on startup. See the [`mcp_servers`](./config.md#mcp_servers) section in the configuration documentation for details.
 
-It is still experimental, but you can also launch Codex as an MCP _server_ by running `codex mcp`. Use the [`@modelcontextprotocol/inspector`](https://github.com/modelcontextprotocol/inspector) to try it out:
+It is still experimental, but you can also launch Codex as an MCP _server_ by running `codex mcp`. Use the [`@modelcontextprotocol/inspector`](https://github.com/modelcontextprotocol/inspector) to try it out.
+A smolagents-based Python client lives in `mcp-client/py` and can cooperate with other agents. A minimal `mcp_server.py` script demonstrates how to expose tools purely in Python.
 
 ```shell
 npx @modelcontextprotocol/inspector codex mcp
@@ -67,3 +68,7 @@ This folder is the root of a Cargo workspace. It contains quite a bit of experim
 - [`exec/`](./exec) "headless" CLI for use in automation.
 - [`tui/`](./tui) CLI that launches a fullscreen TUI built with [Ratatui](https://ratatui.rs/).
 - [`cli/`](./cli) CLI multitool that provides the aforementioned CLIs via subcommands.
+- [`apply-patch/src/py`](./apply-patch/src/py) Python port of `seek_sequence` used for patch utilities.
+- [`mcp-client/py`](./mcp-client/py) Python implementation of the MCP client using `smolagents`.
+- [`mcp-client/py/mcp_server.py`](./mcp-client/py/mcp_server.py) Example MCP server written in Python.
+- [`../yowon`](../yowon) Minimal `uv` project exposing an OpenAI-only CLI and MCP server with conversational context.

--- a/codex-rs/apply-patch/src/py/seek_sequence.py
+++ b/codex-rs/apply-patch/src/py/seek_sequence.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+# This is a Python reimplementation of the `seek_sequence` function from
+# `seek_sequence.rs`. The goal is feature parity with the Rust version so that
+# Python tools can share the same patch-parsing logic.
+
+
+_DASHES = {
+    "\u2010": "-",
+    "\u2011": "-",
+    "\u2012": "-",
+    "\u2013": "-",
+    "\u2014": "-",
+    "\u2015": "-",
+    "\u2212": "-",
+}
+
+_SINGLE_QUOTES = {
+    "\u2018": "'",
+    "\u2019": "'",
+    "\u201A": "'",
+    "\u201B": "'",
+}
+
+_DOUBLE_QUOTES = {
+    "\u201C": '"',
+    "\u201D": '"',
+    "\u201E": '"',
+    "\u201F": '"',
+}
+
+_SPACES = {
+    "\u00A0": " ",
+    "\u2002": " ",
+    "\u2003": " ",
+    "\u2004": " ",
+    "\u2005": " ",
+    "\u2006": " ",
+    "\u2007": " ",
+    "\u2008": " ",
+    "\u2009": " ",
+    "\u200A": " ",
+    "\u202F": " ",
+    "\u205F": " ",
+    "\u3000": " ",
+}
+
+
+def _normalise(s: str) -> str:
+    table = {**_DASHES, **_SINGLE_QUOTES, **_DOUBLE_QUOTES, **_SPACES}
+    return ''.join(table.get(ch, ch) for ch in s.strip())
+
+
+def seek_sequence(
+    lines: List[str],
+    pattern: List[str],
+    start: int,
+    eof: bool,
+) -> Optional[int]:
+    """Find a subsequence within ``lines`` that matches ``pattern``.
+
+    This function mirrors the behaviour of ``seek_sequence`` in Rust and returns
+    the starting index of the match or ``None`` if not found.
+    """
+    if not pattern:
+        return start
+
+    if len(pattern) > len(lines):
+        return None
+
+    search_start = len(lines) - len(pattern) if eof and len(lines) >= len(pattern) else start
+
+    # Exact match
+    for i in range(search_start, len(lines) - len(pattern) + 1):
+        if lines[i:i + len(pattern)] == pattern:
+            return i
+
+    # Match ignoring trailing whitespace
+    for i in range(search_start, len(lines) - len(pattern) + 1):
+        for p_idx, pat in enumerate(pattern):
+            if lines[i + p_idx].rstrip() != pat.rstrip():
+                break
+        else:
+            return i
+
+    # Match ignoring leading and trailing whitespace
+    for i in range(search_start, len(lines) - len(pattern) + 1):
+        for p_idx, pat in enumerate(pattern):
+            if lines[i + p_idx].strip() != pat.strip():
+                break
+        else:
+            return i
+
+    # Normalised match for fancy punctuation
+    for i in range(search_start, len(lines) - len(pattern) + 1):
+        for p_idx, pat in enumerate(pattern):
+            if _normalise(lines[i + p_idx]) != _normalise(pat):
+                break
+        else:
+            return i
+
+    return None
+

--- a/codex-rs/apply-patch/src/py/test_seek_sequence.py
+++ b/codex-rs/apply-patch/src/py/test_seek_sequence.py
@@ -1,0 +1,34 @@
+import unittest
+
+from seek_sequence import seek_sequence
+
+
+def to_vec(strings):
+    return [s for s in strings]
+
+
+class SeekSequenceTests(unittest.TestCase):
+    def test_exact_match_finds_sequence(self):
+        lines = to_vec(["foo", "bar", "baz"])
+        pattern = to_vec(["bar", "baz"])
+        self.assertEqual(seek_sequence(lines, pattern, 0, False), 1)
+
+    def test_rstrip_match_ignores_trailing_whitespace(self):
+        lines = to_vec(["foo   ", "bar\t\t"])
+        pattern = to_vec(["foo", "bar"])
+        self.assertEqual(seek_sequence(lines, pattern, 0, False), 0)
+
+    def test_trim_match_ignores_leading_and_trailing_whitespace(self):
+        lines = to_vec(["    foo   ", "   bar\t"])
+        pattern = to_vec(["foo", "bar"])
+        self.assertEqual(seek_sequence(lines, pattern, 0, False), 0)
+
+    def test_pattern_longer_than_input_returns_none(self):
+        lines = to_vec(["just one line"])
+        pattern = to_vec(["too", "many", "lines"])
+        self.assertIsNone(seek_sequence(lines, pattern, 0, False))
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/codex-rs/mcp-client/py/mcp_client.py
+++ b/codex-rs/mcp-client/py/mcp_client.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+from mcp import StdioServerParameters
+from smolagents.mcp_client import MCPClient as _MCPClient
+
+
+class McpClient:
+    """Thin wrapper around ``smolagents`` `MCPClient`.
+
+    It exposes the remote tools as regular Python callables so they can
+    cooperate with other agents.
+    """
+
+    def __init__(self, params: StdioServerParameters | dict[str, Any] | List[StdioServerParameters | dict[str, Any]]):
+        self._client = _MCPClient(params)
+
+    def get_tools(self):
+        """Return the list of SmolAgent-compatible tools."""
+        return self._client.get_tools()
+
+    def __enter__(self):
+        return self._client.__enter__()
+
+    def __exit__(self, exc_type, exc, tb):
+        return self._client.__exit__(exc_type, exc, tb)

--- a/codex-rs/mcp-client/py/mcp_server.py
+++ b/codex-rs/mcp-client/py/mcp_server.py
@@ -1,0 +1,41 @@
+"""Minimal MCP server implemented in Python using the `mcp` package."""
+
+import anyio
+from mcp.server.lowlevel.server import Server, NotificationOptions
+from mcp.server.models import InitializationOptions
+from mcp.server.stdio import stdio_server
+from mcp.types import ServerCapabilities, Tool, TextContent
+
+server = Server("codex-python")
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    return [
+        Tool(
+            name="echo",
+            description="Echo input text",
+            inputSchema={"type": "object", "properties": {"text": {"type": "string", "description": "text to echo"}}},
+        )
+    ]
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict | None):
+    if name == "echo":
+        text = (arguments or {}).get("text", "")
+        return [TextContent(text=text)]
+    raise ValueError(f"unknown tool: {name}")
+
+async def main() -> None:
+    async with stdio_server() as (read, write):
+        await server.run(
+            read,
+            write,
+            InitializationOptions(
+                server_name="codex-python",
+                server_version="0.1",
+                capabilities=ServerCapabilities(),
+            ),
+        )
+
+if __name__ == "__main__":
+    anyio.run(main)

--- a/codex-rs/mcp-client/py/test_mcp_client.py
+++ b/codex-rs/mcp-client/py/test_mcp_client.py
@@ -1,0 +1,52 @@
+import sys
+import os
+sys.path.insert(0, os.path.dirname(__file__))
+
+import unittest
+from mcp import StdioServerParameters
+from mcp_client import McpClient
+
+SERVER_SCRIPT = r"""
+import anyio
+from mcp.server.lowlevel.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.server.models import InitializationOptions
+from mcp.types import ServerCapabilities, Tool, TextContent
+
+server = Server("py-test")
+
+@server.list_tools()
+async def list_tools():
+    return [
+        Tool(
+            name="ping",
+            description="ping",
+            inputSchema={
+                "type": "object",
+                "properties": {"text": {"type": "string", "description": "ignored"}},
+            },
+        )
+    ]
+
+@server.call_tool()
+async def call_tool(name, arguments):
+    return [TextContent(text="pong")]
+
+async def main():
+    async with stdio_server() as (r, w):
+        await server.run(r, w, InitializationOptions(server_name="py-test", server_version="0.1", capabilities=ServerCapabilities()))
+
+anyio.run(main)
+"""
+
+
+class McpClientTests(unittest.TestCase):
+    def test_can_list_tools(self):
+        params = StdioServerParameters(command=sys.executable, args=["-u", "-c", SERVER_SCRIPT])
+        client = McpClient(params)
+        with client as tools:
+            self.assertEqual(len(tools), 1)
+            self.assertEqual(tools[0].name, "ping")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yowon/README.md
+++ b/yowon/README.md
@@ -1,0 +1,25 @@
+# Yowon
+
+`yowon` is a tiny Python project built with [uv](https://github.com/astral-sh/uv). It exposes a CLI and an MCP server that rely exclusively on the OpenAI model via `smolagents`.
+
+## Usage
+
+### CLI
+
+```bash
+yowon run "Hello"
+```
+
+For a conversation that keeps context between prompts:
+
+```bash
+yowon chat
+```
+
+### MCP Server
+
+```bash
+yowon serve
+```
+
+This will start an MCP server over stdio so it can cooperate with other agents.

--- a/yowon/pyproject.toml
+++ b/yowon/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "yowon"
+version = "0.1.0"
+description = "OpenAI-only smolagents CLI and MCP server"
+authors = [{name = "OpenAI"}]
+dependencies = [
+    "smolagents[openai,mcp]>=1.18.0",
+    "anyio>=3.5",
+    "click>=8.1",
+]
+
+[project.scripts]
+yowon = "yowon.cli:cli"
+yowon-mcp = "yowon.server:main"
+
+[tool.uv]
+# This section allows `uv` to create an isolated environment

--- a/yowon/test_chat_session.py
+++ b/yowon/test_chat_session.py
@@ -1,0 +1,25 @@
+import unittest
+import yowon.agent as agent
+
+class FakeAgent:
+    def __init__(self):
+        self.calls = []
+    def run(self, prompt, reset=True, **kwargs):
+        self.calls.append((prompt, reset))
+        return f"echo:{prompt}-{reset}"
+
+class ChatSessionTests(unittest.TestCase):
+    def test_maintains_reset_flag(self):
+        original = agent.create_agent
+        try:
+            agent.create_agent = lambda **kwargs: FakeAgent()
+            session = agent.ChatSession()
+            first = session.ask("hi")
+            second = session.ask("again")
+        finally:
+            agent.create_agent = original
+        self.assertEqual(first, "echo:hi-True")
+        self.assertEqual(second, "echo:again-False")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yowon/yowon/__main__.py
+++ b/yowon/yowon/__main__.py
@@ -1,0 +1,4 @@
+from .cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/yowon/yowon/agent.py
+++ b/yowon/yowon/agent.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+from smolagents import CodeAgent, OpenAIServerModel
+
+DEFAULT_MODEL = "codex-mini-latest"
+
+
+class ChatSession:
+    """Keep conversation state across multiple agent runs."""
+
+    def __init__(self, model_id: str = DEFAULT_MODEL, api_key: str | None = None) -> None:
+        self._agent = create_agent(model_id=model_id, api_key=api_key)
+        self._reset = True
+
+    def ask(self, prompt: str) -> str:
+        result = self._agent.run(prompt, reset=self._reset)
+        self._reset = False
+        return result
+
+    def reset(self) -> None:
+        self._reset = True
+
+
+def create_agent(model_id: str = DEFAULT_MODEL, api_key: str | None = None) -> CodeAgent:
+    """Return a `CodeAgent` using the OpenAI model."""
+    api_key = api_key or os.getenv("OPENAI_API_KEY")
+    model = OpenAIServerModel(model_id=model_id, api_key=api_key)
+    return CodeAgent(model=model, tools=[])

--- a/yowon/yowon/cli.py
+++ b/yowon/yowon/cli.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import anyio
+import click
+
+from .agent import create_agent, DEFAULT_MODEL, ChatSession
+from .server import main as serve_main
+
+
+@click.group()
+def cli() -> None:
+    """CLI entry point for yowon."""
+
+
+@cli.command()
+@click.argument("prompt")
+@click.option("--model", default=DEFAULT_MODEL, show_default=True)
+@click.option("--api-key", envvar="OPENAI_API_KEY", help="OpenAI API key")
+def run(prompt: str, model: str, api_key: str | None) -> None:
+    """Run the agent once with PROMPT."""
+    agent = create_agent(model_id=model, api_key=api_key)
+    result = agent.run(prompt)
+    print(result)
+
+
+@cli.command()
+@click.option("--model", default=DEFAULT_MODEL, show_default=True)
+@click.option("--api-key", envvar="OPENAI_API_KEY", help="OpenAI API key")
+def chat(model: str, api_key: str | None) -> None:
+    """Run an interactive chat session."""
+    session = ChatSession(model_id=model, api_key=api_key)
+    while True:
+        try:
+            prompt = input("\u003e ")
+        except EOFError:
+            break
+        if not prompt:
+            continue
+        if prompt.strip().lower() in {"exit", "quit"}:
+            break
+        answer = session.ask(prompt)
+        print(answer)
+
+
+@cli.command()
+@click.option("--port", type=int, default=None, help="Ignored for now")
+def serve(port: int | None) -> None:
+    """Launch the MCP server over stdio."""
+    anyio.run(serve_main)
+
+
+if __name__ == "__main__":
+    cli()

--- a/yowon/yowon/server.py
+++ b/yowon/yowon/server.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import anyio
+from mcp.server.lowlevel.server import Server
+from mcp.server.models import InitializationOptions
+from mcp.server.stdio import stdio_server
+from mcp.types import ServerCapabilities, Tool, TextContent
+
+from .agent import ChatSession
+
+server = Server("yowon")
+session = ChatSession()
+
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    return [
+        Tool(
+            name="openai_chat",
+            description="Generate a response with OpenAI",
+            inputSchema={
+                "type": "object",
+                "properties": {"prompt": {"type": "string", "description": "user prompt"}},
+            },
+        )
+    ]
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict | None):
+    if name == "openai_chat":
+        prompt = (arguments or {}).get("prompt", "")
+        answer = session.ask(prompt)
+        return [TextContent(text=str(answer))]
+    raise ValueError(f"unknown tool: {name}")
+
+
+async def main() -> None:
+    async with stdio_server() as (read, write):
+        await server.run(
+            read,
+            write,
+            InitializationOptions(server_name="yowon", server_version="0.1", capabilities=ServerCapabilities()),
+        )
+
+
+if __name__ == "__main__":
+    anyio.run(main)


### PR DESCRIPTION
## Summary
- add `ChatSession` to keep conversation history
- implement interactive `chat` CLI command
- share the same chat context in the MCP server
- document context-aware usage
- test `ChatSession`

## Testing
- `pnpm install`
- `pnpm test` *(fails: Process with PID failed to terminate)*
- `python codex-rs/apply-patch/src/py/test_seek_sequence.py -v`
- `python codex-rs/mcp-client/py/test_mcp_client.py -v`
- `python yowon/test_chat_session.py -v`


------
https://chatgpt.com/codex/tasks/task_e_68536b9855e8832dbb911ce2dc0aad98